### PR TITLE
Fix color selection bug and typo

### DIFF
--- a/game.js
+++ b/game.js
@@ -78,7 +78,8 @@ function nextSequence() {
   $("#level-title").text("Level " + level);
 
   // Pushes Random Color to gamePattern[]
-  var randomNumber = Math.floor((Math.random() * 3) + 1);
+  // There are four colours in buttonColors, generate a value between 0-3
+  var randomNumber = Math.floor(Math.random() * buttonColors.length);
   var randomChosenColor = buttonColors[randomNumber];
   gamePattern.push(randomChosenColor);
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <h1 id="level-title">Press Any Key to Start</h1>
 
     <div class="container">
-      <div lass="row">
+      <div class="row">
 
         <div type="button" id="green" class="btn green"></div>
 


### PR DESCRIPTION
## Summary
- ensure `nextSequence` selects among all four colors
- correct typo in `index.html` row div

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68424e9397b4832891d713eb84e950de