### PR TITLE
Add Jest test for startOver functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ HTML, CSS, Javascript
 
 ### Test Your Skills
 (https://deroest6.github.io/Simon-Game/) - Simon Game
+
+### Running Tests
+
+1. Install dependencies with `npm install`.
+2. Run the test suite with `npm test`.

--- a/game.js
+++ b/game.js
@@ -7,27 +7,30 @@ var level = 0;
 
 var started = false;
 
-$(document).keydown(function() {
-  if (!started) { // Start = False
-    $("h1").text("Level " + level);
-    nextSequence();
-    started = true;
-  }
-});
+if (typeof $ !== "undefined") {
+  $(document).keydown(function() {
+    if (!started) { // Start = False
+      $("h1").text("Level " + level);
+      nextSequence();
+      started = true;
+    }
+  });
 
 
-// Takes the color user clicks on and returns it to userClickedPattern
-$(".btn").click(function() {
+  // Takes the color user clicks on and returns it to userClickedPattern
+  $(".btn").click(function() {
 
-  var userChosenColor = $(this).attr("id");
-  userClickedPattern.push(userChosenColor);
+    var userChosenColor = $(this).attr("id");
+    userClickedPattern.push(userChosenColor);
 
-  playSound(userChosenColor);
-  animatePress(userChosenColor);
+    playSound(userChosenColor);
+    animatePress(userChosenColor);
 
-  console.log("Start checking answer...");
-  checkAnswer(userClickedPattern.length - 1);
-});
+    console.log("Start checking answer...");
+    checkAnswer(userClickedPattern.length - 1);
+  });
+}
+
 
 
 // Checks the usersChosenColor to the current gamePattern IF true you advance to next level
@@ -103,6 +106,18 @@ function animatePress(currentColor) {
   setTimeout(function() {
     $("#" + currentColor).removeClass("pressed");
   }, 100);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    startOver: startOver,
+    getLevel: function () { return level; },
+    getGamePattern: function () { return gamePattern; },
+    getUserClickedPattern: function () { return userClickedPattern; },
+    setLevel: function (val) { level = val; },
+    setGamePattern: function (val) { gamePattern = val; },
+    setUserClickedPattern: function (val) { userClickedPattern = val; }
+  };
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "simon-game",
+  "version": "1.0.0",
+  "description": "This is my take on the classic Simon Game. Test your memory by remembering the sequence in which the buttons light up. Careful the pattern does not restart (repeat itself) so you have to remember every step from beginning to end.",
+  "main": "game-cheat.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,0 +1,16 @@
+const game = require('../game');
+
+describe('startOver', () => {
+  test('resets level, gamePattern, and userClickedPattern', () => {
+    // Set up non-default state
+    game.setLevel(5);
+    game.setGamePattern(['red', 'blue']);
+    game.setUserClickedPattern(['green']);
+
+    game.startOver();
+
+    expect(game.getLevel()).toBe(0);
+    expect(game.getGamePattern()).toEqual([]);
+    expect(game.getUserClickedPattern()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- init npm project and add Jest
- export variables from `game.js` when running in Node
- add a test for `startOver`
- document test instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424f960cf08328a2cd977f8ae3b66b